### PR TITLE
Fixed constructor insertion when matching with properties having a multiline declaration as last properties.

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,11 @@
                     "type": "string",
                     "default": "protected",
                     "description": "Default property visibility modifier"
+                },
+                "phpConstructor.constructor_visibility": {
+                    "type": "string",
+                    "default": "public",
+                    "description": "Default constructor visibility modifier"
                 }
             }
         }

--- a/src/PropertyInserter.js
+++ b/src/PropertyInserter.js
@@ -111,14 +111,14 @@ module.exports = class PropertyInserter {
         let constructorLineText = this.activeEditor().document.getText(declarations.constructorRange);
 
         // Split constructor arguments.
-        let consturctor = constructorLineText.split(/\((.+?)\)/);
+        let constructor = constructorLineText.split(/\((.+?)\)/);
 
         // Escape all "$" signs of constructor arguments otherwise
         // vscode will assume "$" sign is a snippet placeholder.
-        let previousVars = consturctor[1].replace(/\$/g, '\\$');
+        let previousVars = constructor[1].replace(/\$/g, '\\$');
 
         // Merge constructor line with new snippet placeholder.
-        snippet += `${consturctor[0]}(${previousVars}\,\ \\$\${1:property})`;
+        snippet += `${constructor[0]}(${previousVars}\,\ \\$\${1:property})`;
 
         let constructorClosingLine;
 

--- a/src/PropertyInserter.js
+++ b/src/PropertyInserter.js
@@ -78,7 +78,7 @@ module.exports = class PropertyInserter {
         }
 
         snippet += `\t${this.config('visibility')}` + ' \\$${1:property};\n\n' +
-        '\tpublic function __construct(\\$${1:property})\n' +
+        `\t${this.config('constructor_visibility')}` + ' function __construct(\\$${1:property})\n' +
         '\t{\n' +
             '\t\t\\$this->${1:property} = \\$${1:property};$0\n' +
         '\t}';

--- a/src/PropertyInserter.js
+++ b/src/PropertyInserter.js
@@ -48,7 +48,7 @@ module.exports = class PropertyInserter {
             }
 
             if (/(public|protected|private|static) \$/.test(textLine)) {
-                declarations.lastPropertyLineNumber = line;
+                declarations.lastPropertyLineNumber = this.findPropertyLastLine(doc, line, textLine);
             }
 
             if (/function __construct\(/.test(textLine)) {
@@ -178,6 +178,18 @@ module.exports = class PropertyInserter {
         let lineNumber = declarations.lastPropertyLineNumber || declarations.traitUseLineNumber || declarations.classLineNumber;
 
         return ++lineNumber;
+    }
+
+    findPropertyLastLine(doc, start) {
+        for (let line = start; line < doc.lineCount; line++) {
+            let textLine = doc.lineAt(line).text;
+
+            if (textLine.trim().endsWith(';')) {
+                return line;
+            }
+        }
+
+        throw 'Invalid PHP file. At least one property is not properly closed.';
     }
 
     activeEditor() {


### PR DESCRIPTION
Hello! First off, thank you for building this extension. I had a custom snippet to generate constructors, but it was very limited as I couldn't add new properties automatically. Thus, I started to use your extension, and immediately I was thrilled.

However, I happened to find a bug. Whenever you had multiline declarations of properties such as an array, the extension would add the constructor inside of the array. Let's say we have the following class:

```php
<?php

class User
{
    use Hello;

    protected $table;

    protected $attributes = [
        // When inserting the constructor, unfortunately it is inserted here.
        'name', 'email', 'password',
    ];

    // Constructor should be inserted here.
}
```

This happens because the extension only cares when a property begins ([code](https://github.com/MehediDracula/PHP-Constructor/blob/cf7ee9225ea38aaec0cb1f584bd6a4c3da70f08a/src/PropertyInserter.js#L50)). This PR starts a new search to find the very next `;` character, which can be the current line or the next ones. If no `;` is found, an exception is thrown.

Oh, and I also fixed a typo I found.

I'm looking forward to see what you think! :)