### PR TITLE
Hardcode the space next to constructor visibility

### DIFF
--- a/src/PropertyInserter.js
+++ b/src/PropertyInserter.js
@@ -78,7 +78,7 @@ module.exports = class PropertyInserter {
         }
 
         snippet += `\t${this.config('visibility')}` + ' \\$${1:property};\n\n' +
-        `\t${this.config('constructor_visibility')}` + ' function __construct(\\$${1:property})\n' +
+        `\t${this.config('constructor_visibility')} ` + 'function __construct(\\$${1:property})\n' +
         '\t{\n' +
             '\t\t\\$this->${1:property} = \\$${1:property};$0\n' +
         '\t}';


### PR DESCRIPTION
With this, you can set `"phpConstructor.constructor_visibility": ""` and have this:
```php
function __construct($property)
{
    $this->property = $property;
}
```
without a space preceding `function`
![](https://i.imgur.com/eNzcuQh.png)