### PR TITLE
Prefer language specific tab-size

### DIFF
--- a/src/PropertyInserter.js
+++ b/src/PropertyInserter.js
@@ -306,10 +306,20 @@ class PropertyInserter {
         if (! vscode.workspace.getConfiguration('editor', activeResource).get('insertSpaces')) {
             singleLevel = '\t';
         } else {
-            singleLevel = ' '.repeat(vscode.workspace.getConfiguration('editor', activeResource).get('tabSize'));
+            singleLevel = ' '.repeat(this.getTabSize());
         }
 
         return singleLevel.repeat(level);
+    }
+
+    getTabSize() {
+        let phpTabSize = vscode.workspace.getConfiguration('[php]')['editor.tabSize'];
+
+        if (phpTabSize) {
+            return phpTabSize;
+        }
+
+        return vscode.workspace.getConfiguration('editor').get('tabSize');
     }
 
     getVisibilityChoice(defaultValue) {


### PR DESCRIPTION
Thanks for your extension.
I have noticed a small issue, when we use different indentation setting for PHP language in config file, the extension is still use editor's value.
This small PR fixing described behavior by checking language specific setting first.